### PR TITLE
feat: Add Dark Mode Support

### DIFF
--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1,0 +1,500 @@
+/* Dark Mode Theme for Smart Attendance System */
+
+/* CSS Variables for Dark Mode */
+[data-theme="dark"] {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-tertiary: #0f3460;
+    --bg-card: #1e2746;
+    --bg-input: #2a3550;
+    --bg-hover: #2d3a5a;
+    
+    --text-primary: #e8e8e8;
+    --text-secondary: #b0b0b0;
+    --text-muted: #808080;
+    --text-inverse: #1a1a2e;
+    
+    --border-color: #3a4a6a;
+    --border-light: #2d3a5a;
+    
+    --accent-primary: #4361ee;
+    --accent-success: #2ec4b6;
+    --accent-warning: #ff9f1c;
+    --accent-danger: #e63946;
+    --accent-info: #7209b7;
+    
+    --shadow-color: rgba(0, 0, 0, 0.3);
+    --glass-bg: rgba(30, 39, 70, 0.8);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    
+    --nav-bg: rgba(22, 33, 62, 0.95);
+    --dropdown-bg: #1e2746;
+    --table-stripe: rgba(255, 255, 255, 0.02);
+    --table-hover: rgba(255, 255, 255, 0.05);
+}
+
+/* Light Mode Variables (default) */
+[data-theme="light"], :root {
+    --bg-primary: #ffffff;
+    --bg-secondary: #f8f9fa;
+    --bg-tertiary: #e9ecef;
+    --bg-card: #ffffff;
+    --bg-input: #ffffff;
+    --bg-hover: #f0f0f0;
+    
+    --text-primary: #1a1a2e;
+    --text-secondary: #495057;
+    --text-muted: #6c757d;
+    --text-inverse: #ffffff;
+    
+    --border-color: #dee2e6;
+    --border-light: #e9ecef;
+    
+    --accent-primary: #4361ee;
+    --accent-success: #2ec4b6;
+    --accent-warning: #ff9f1c;
+    --accent-danger: #e63946;
+    --accent-info: #7209b7;
+    
+    --shadow-color: rgba(0, 0, 0, 0.1);
+    --glass-bg: rgba(255, 255, 255, 0.8);
+    --glass-border: rgba(0, 0, 0, 0.1);
+    
+    --nav-bg: rgba(255, 255, 255, 0.95);
+    --dropdown-bg: #ffffff;
+    --table-stripe: rgba(0, 0, 0, 0.02);
+    --table-hover: rgba(0, 0, 0, 0.05);
+}
+
+/* Apply theme variables */
+body {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Navigation */
+[data-theme="dark"] .glass-nav,
+[data-theme="dark"] .navbar {
+    background: var(--nav-bg) !important;
+    border-bottom: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .navbar-brand,
+[data-theme="dark"] .brand-text {
+    color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .nav-link,
+[data-theme="dark"] .nav-link-enhanced {
+    color: var(--text-secondary) !important;
+}
+
+[data-theme="dark"] .nav-link:hover,
+[data-theme="dark"] .nav-link-enhanced:hover,
+[data-theme="dark"] .nav-link.current-page {
+    color: var(--accent-primary) !important;
+}
+
+[data-theme="dark"] .dropdown-menu,
+[data-theme="dark"] .glass-dropdown {
+    background: var(--dropdown-bg) !important;
+    border: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .dropdown-item {
+    color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .dropdown-item:hover {
+    background: var(--bg-hover) !important;
+}
+
+/* Cards */
+[data-theme="dark"] .card,
+[data-theme="dark"] .stat-card,
+[data-theme="dark"] .chart-card,
+[data-theme="dark"] .table-card {
+    background: var(--bg-card) !important;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 2px 8px var(--shadow-color);
+}
+
+[data-theme="dark"] .card-header {
+    background: var(--bg-tertiary) !important;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .card-body {
+    color: var(--text-primary);
+}
+
+/* Tables */
+[data-theme="dark"] .table {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .table thead th {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .table td,
+[data-theme="dark"] .table th {
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .table-striped tbody tr:nth-of-type(odd) {
+    background-color: var(--table-stripe);
+}
+
+[data-theme="dark"] .table-hover tbody tr:hover {
+    background-color: var(--table-hover);
+}
+
+[data-theme="dark"] .data-table th {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .data-table td {
+    color: var(--text-primary);
+    border-color: var(--border-color);
+}
+
+/* Forms */
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .form-select,
+[data-theme="dark"] input,
+[data-theme="dark"] select,
+[data-theme="dark"] textarea {
+    background-color: var(--bg-input) !important;
+    border-color: var(--border-color) !important;
+    color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .form-control:focus,
+[data-theme="dark"] .form-select:focus {
+    background-color: var(--bg-input) !important;
+    border-color: var(--accent-primary) !important;
+    box-shadow: 0 0 0 0.2rem rgba(67, 97, 238, 0.25);
+}
+
+[data-theme="dark"] .form-control::placeholder {
+    color: var(--text-muted) !important;
+}
+
+[data-theme="dark"] .form-label,
+[data-theme="dark"] label {
+    color: var(--text-primary);
+}
+
+/* Buttons */
+[data-theme="dark"] .btn-outline-primary {
+    color: var(--accent-primary);
+    border-color: var(--accent-primary);
+}
+
+[data-theme="dark"] .btn-outline-secondary {
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .btn-outline-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .btn-light {
+    background: var(--bg-tertiary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+/* Alerts */
+[data-theme="dark"] .alert {
+    border: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .alert-success {
+    background: rgba(46, 196, 182, 0.15);
+    color: #5dd9cd;
+}
+
+[data-theme="dark"] .alert-danger {
+    background: rgba(230, 57, 70, 0.15);
+    color: #f07178;
+}
+
+[data-theme="dark"] .alert-warning {
+    background: rgba(255, 159, 28, 0.15);
+    color: #ffb347;
+}
+
+[data-theme="dark"] .alert-info {
+    background: rgba(67, 97, 238, 0.15);
+    color: #7b9cf7;
+}
+
+/* Modals */
+[data-theme="dark"] .modal-content {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .modal-header {
+    border-bottom-color: var(--border-color);
+}
+
+[data-theme="dark"] .modal-footer {
+    border-top-color: var(--border-color);
+}
+
+[data-theme="dark"] .modal-title {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .btn-close {
+    filter: invert(1);
+}
+
+/* Badges */
+[data-theme="dark"] .badge {
+    border: 1px solid transparent;
+}
+
+[data-theme="dark"] .rate-badge.excellent {
+    background: rgba(46, 196, 182, 0.2);
+    color: #5dd9cd;
+}
+
+[data-theme="dark"] .rate-badge.good {
+    background: rgba(67, 97, 238, 0.2);
+    color: #7b9cf7;
+}
+
+[data-theme="dark"] .rate-badge.warning {
+    background: rgba(255, 159, 28, 0.2);
+    color: #ffb347;
+}
+
+[data-theme="dark"] .rate-badge.danger {
+    background: rgba(230, 57, 70, 0.2);
+    color: #f07178;
+}
+
+/* Stats */
+[data-theme="dark"] .stat-label {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .stat-value {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .stat-suffix {
+    color: var(--text-muted);
+}
+
+/* Page titles */
+[data-theme="dark"] .page-title,
+[data-theme="dark"] .chart-title,
+[data-theme="dark"] .table-title,
+[data-theme="dark"] h1, [data-theme="dark"] h2, 
+[data-theme="dark"] h3, [data-theme="dark"] h4 {
+    color: var(--text-primary);
+}
+
+/* Activity feed */
+[data-theme="dark"] .activity-item {
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .activity-name {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .activity-meta {
+    color: var(--text-muted);
+}
+
+/* Filter controls */
+[data-theme="dark"] .filter-controls select {
+    background: var(--bg-input);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+/* Scrollbar */
+[data-theme="dark"] ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-track {
+    background: var(--bg-secondary);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+    background: var(--border-color);
+    border-radius: 4px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Theme Toggle Button */
+.theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: none;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    margin-left: 12px;
+}
+
+.theme-toggle:hover {
+    background: var(--accent-primary);
+    color: white;
+    transform: scale(1.05);
+}
+
+.theme-toggle i {
+    font-size: 18px;
+    transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover i {
+    transform: rotate(15deg);
+}
+
+[data-theme="dark"] .theme-toggle .fa-moon {
+    display: none;
+}
+
+[data-theme="dark"] .theme-toggle .fa-sun {
+    display: inline-block;
+}
+
+[data-theme="light"] .theme-toggle .fa-sun {
+    display: none;
+}
+
+[data-theme="light"] .theme-toggle .fa-moon {
+    display: inline-block;
+}
+
+/* Smooth transitions */
+.card, .btn, .form-control, .nav-link, .dropdown-menu,
+.table, .alert, .modal-content, .badge {
+    transition: background-color 0.3s ease, 
+                border-color 0.3s ease, 
+                color 0.3s ease,
+                box-shadow 0.3s ease;
+}
+
+/* Chart.js dark mode support */
+[data-theme="dark"] .chart-container canvas {
+    filter: none;
+}
+
+/* Video feed container */
+[data-theme="dark"] .video-container,
+[data-theme="dark"] .camera-feed {
+    background: var(--bg-tertiary);
+    border-color: var(--border-color);
+}
+
+/* Leave management specific */
+[data-theme="dark"] .leave-card {
+    background: var(--bg-card);
+    border-color: var(--border-color);
+}
+
+/* Student cards */
+[data-theme="dark"] .student-card {
+    background: var(--bg-card);
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .student-card:hover {
+    background: var(--bg-hover);
+}
+
+/* Links */
+[data-theme="dark"] a:not(.btn):not(.nav-link) {
+    color: var(--accent-primary);
+}
+
+[data-theme="dark"] a:not(.btn):not(.nav-link):hover {
+    color: #6b8cff;
+}
+
+/* Code blocks */
+[data-theme="dark"] code,
+[data-theme="dark"] pre {
+    background: var(--bg-tertiary);
+    color: #e8e8e8;
+}
+
+/* HR */
+[data-theme="dark"] hr {
+    border-color: var(--border-color);
+}
+
+/* List groups */
+[data-theme="dark"] .list-group-item {
+    background: var(--bg-card);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .list-group-item:hover {
+    background: var(--bg-hover);
+}
+
+/* Pagination */
+[data-theme="dark"] .page-link {
+    background: var(--bg-card);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .page-link:hover {
+    background: var(--bg-hover);
+}
+
+[data-theme="dark"] .page-item.active .page-link {
+    background: var(--accent-primary);
+    border-color: var(--accent-primary);
+}
+
+/* Progress bars */
+[data-theme="dark"] .progress {
+    background: var(--bg-tertiary);
+}
+
+/* Tooltips */
+[data-theme="dark"] .tooltip-inner {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+}
+
+/* Print styles - always light */
+@media print {
+    [data-theme="dark"] {
+        --bg-primary: #ffffff;
+        --bg-secondary: #f8f9fa;
+        --text-primary: #1a1a2e;
+        --text-secondary: #495057;
+    }
+}

--- a/static/js/dark-mode.js
+++ b/static/js/dark-mode.js
@@ -1,0 +1,188 @@
+/**
+ * Dark Mode Toggle for Smart Attendance System
+ * Handles theme switching with localStorage persistence
+ */
+
+(function() {
+    'use strict';
+
+    const THEME_KEY = 'smart-attendance-theme';
+    const DARK = 'dark';
+    const LIGHT = 'light';
+
+    /**
+     * Get the current theme from localStorage or system preference
+     */
+    function getStoredTheme() {
+        const stored = localStorage.getItem(THEME_KEY);
+        if (stored) {
+            return stored;
+        }
+        
+        // Check system preference
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            return DARK;
+        }
+        
+        return LIGHT;
+    }
+
+    /**
+     * Set the theme on the document
+     */
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem(THEME_KEY, theme);
+        
+        // Update toggle button icon
+        updateToggleIcon(theme);
+        
+        // Update Chart.js if present
+        updateChartColors(theme);
+        
+        // Dispatch custom event for other scripts
+        window.dispatchEvent(new CustomEvent('themechange', { detail: { theme } }));
+    }
+
+    /**
+     * Toggle between light and dark themes
+     */
+    function toggleTheme() {
+        const current = document.documentElement.getAttribute('data-theme') || LIGHT;
+        const newTheme = current === DARK ? LIGHT : DARK;
+        setTheme(newTheme);
+    }
+
+    /**
+     * Update the toggle button icon
+     */
+    function updateToggleIcon(theme) {
+        const toggleBtn = document.querySelector('.theme-toggle');
+        if (!toggleBtn) return;
+
+        const sunIcon = toggleBtn.querySelector('.fa-sun');
+        const moonIcon = toggleBtn.querySelector('.fa-moon');
+
+        if (theme === DARK) {
+            if (sunIcon) sunIcon.style.display = 'inline-block';
+            if (moonIcon) moonIcon.style.display = 'none';
+            toggleBtn.setAttribute('aria-label', 'Switch to light mode');
+            toggleBtn.setAttribute('title', 'Switch to light mode');
+        } else {
+            if (sunIcon) sunIcon.style.display = 'none';
+            if (moonIcon) moonIcon.style.display = 'inline-block';
+            toggleBtn.setAttribute('aria-label', 'Switch to dark mode');
+            toggleBtn.setAttribute('title', 'Switch to dark mode');
+        }
+    }
+
+    /**
+     * Update Chart.js colors for dark mode
+     */
+    function updateChartColors(theme) {
+        if (typeof Chart === 'undefined') return;
+
+        const isDark = theme === DARK;
+        const textColor = isDark ? '#e8e8e8' : '#1a1a2e';
+        const gridColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)';
+
+        // Update Chart.js defaults
+        Chart.defaults.color = textColor;
+        Chart.defaults.borderColor = gridColor;
+
+        // Update all existing charts
+        Object.values(Chart.instances || {}).forEach(chart => {
+            if (chart.options.scales) {
+                Object.values(chart.options.scales).forEach(scale => {
+                    if (scale.ticks) scale.ticks.color = textColor;
+                    if (scale.grid) scale.grid.color = gridColor;
+                });
+            }
+            if (chart.options.plugins && chart.options.plugins.legend) {
+                chart.options.plugins.legend.labels = chart.options.plugins.legend.labels || {};
+                chart.options.plugins.legend.labels.color = textColor;
+            }
+            chart.update('none');
+        });
+    }
+
+    /**
+     * Create and inject the theme toggle button
+     */
+    function createToggleButton() {
+        // Check if button already exists
+        if (document.querySelector('.theme-toggle')) return;
+
+        const navbar = document.querySelector('.navbar-nav.me-auto');
+        if (!navbar) return;
+
+        // Create toggle button
+        const toggleBtn = document.createElement('button');
+        toggleBtn.className = 'theme-toggle';
+        toggleBtn.type = 'button';
+        toggleBtn.setAttribute('aria-label', 'Toggle dark mode');
+        toggleBtn.setAttribute('title', 'Toggle dark mode');
+        toggleBtn.innerHTML = `
+            <i class="fas fa-moon" aria-hidden="true"></i>
+            <i class="fas fa-sun" aria-hidden="true"></i>
+        `;
+
+        // Add click handler
+        toggleBtn.addEventListener('click', toggleTheme);
+
+        // Insert after navbar
+        const navbarCollapse = document.querySelector('.navbar-collapse');
+        if (navbarCollapse) {
+            const container = document.createElement('div');
+            container.className = 'd-flex align-items-center';
+            container.appendChild(toggleBtn);
+            navbarCollapse.appendChild(container);
+        }
+    }
+
+    /**
+     * Initialize dark mode
+     */
+    function init() {
+        // Apply stored theme immediately (before DOM ready to prevent flash)
+        const theme = getStoredTheme();
+        document.documentElement.setAttribute('data-theme', theme);
+
+        // Wait for DOM to be ready
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', function() {
+                createToggleButton();
+                updateToggleIcon(theme);
+            });
+        } else {
+            createToggleButton();
+            updateToggleIcon(theme);
+        }
+
+        // Listen for system theme changes
+        if (window.matchMedia) {
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+                // Only auto-switch if user hasn't manually set a preference
+                if (!localStorage.getItem(THEME_KEY)) {
+                    setTheme(e.matches ? DARK : LIGHT);
+                }
+            });
+        }
+    }
+
+    // Expose functions globally
+    window.darkMode = {
+        toggle: toggleTheme,
+        set: setTheme,
+        get: function() {
+            return document.documentElement.getAttribute('data-theme') || LIGHT;
+        },
+        isDark: function() {
+            return this.get() === DARK;
+        }
+    };
+
+    // Initialize
+    init();
+
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,10 @@
     <link href="{{ url_for('static', filename='css/accessibility-enhancements.css') }}" rel="stylesheet" media="print" onload="this.media='all'">
     <!-- Fixed Layout - No Scrolling -->
     <link href="{{ url_for('static', filename='css/fixed-layout.css') }}" rel="stylesheet">
+    <!-- Dark Mode Support -->
+    <link href="{{ url_for('static', filename='css/dark-mode.css') }}" rel="stylesheet">
+    <!-- Dark Mode Script (load early to prevent flash) -->
+    <script src="{{ url_for('static', filename='js/dark-mode.js') }}"></script>
     
     {% block extra_css %}{% endblock %}
 </head>

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -1,0 +1,93 @@
+"""
+Tests for Dark Mode feature
+"""
+import pytest
+import os
+
+
+class TestDarkMode:
+    """Test cases for dark mode feature"""
+    
+    def test_dark_mode_css_exists(self):
+        """Test that dark mode CSS file exists"""
+        css_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'static', 'css', 'dark-mode.css'
+        )
+        assert os.path.exists(css_path), "dark-mode.css should exist"
+    
+    def test_dark_mode_js_exists(self):
+        """Test that dark mode JS file exists"""
+        js_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'static', 'js', 'dark-mode.js'
+        )
+        assert os.path.exists(js_path), "dark-mode.js should exist"
+    
+    def test_dark_mode_css_has_theme_variables(self):
+        """Test that CSS contains theme variables"""
+        css_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'static', 'css', 'dark-mode.css'
+        )
+        with open(css_path, 'r') as f:
+            content = f.read()
+        
+        # Check for dark theme selector
+        assert '[data-theme="dark"]' in content
+        
+        # Check for key CSS variables
+        assert '--bg-primary' in content
+        assert '--text-primary' in content
+        assert '--border-color' in content
+    
+    def test_dark_mode_js_has_toggle_function(self):
+        """Test that JS contains toggle functionality"""
+        js_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'static', 'js', 'dark-mode.js'
+        )
+        with open(js_path, 'r') as f:
+            content = f.read()
+        
+        # Check for key functions
+        assert 'toggleTheme' in content
+        assert 'setTheme' in content
+        assert 'localStorage' in content
+    
+    def test_base_template_includes_dark_mode(self, client):
+        """Test that base template includes dark mode files"""
+        response = client.get('/')
+        assert response.status_code == 200
+        
+        html = response.data.decode('utf-8')
+        assert 'dark-mode.css' in html
+        assert 'dark-mode.js' in html
+    
+    def test_dark_mode_respects_system_preference(self):
+        """Test that JS checks for system preference"""
+        js_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'static', 'js', 'dark-mode.js'
+        )
+        with open(js_path, 'r') as f:
+            content = f.read()
+        
+        assert 'prefers-color-scheme' in content
+
+
+@pytest.fixture
+def client():
+    """Create test client"""
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    
+    from app import app
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    
+    with app.test_client() as client:
+        with app.app_context():
+            from database.models import db
+            db.create_all()
+        yield client


### PR DESCRIPTION
## Description
Adds dark mode theme toggle with system preference detection and localStorage persistence.

Closes #28

## Features

### Theme Toggle
- Toggle button auto-injected in navbar (sun/moon icons)
- Smooth transitions between themes
- Keyboard accessible

### System Integration
- Detects system preference (prefers-color-scheme)
- Persists user choice in localStorage
- Respects manual override

### Styled Components
- Navigation bar
- Cards and stat cards
- Tables (striped, hover)
- Forms (inputs, selects, textareas)
- Buttons and badges
- Modals and alerts
- Dropdowns
- Scrollbars
- Chart.js integration

## Files Added/Modified
- \static/css/dark-mode.css\ - Theme styles with CSS variables
- \static/js/dark-mode.js\ - Toggle logic and persistence
- \	emplates/base.html\ - Include dark mode files
- \	ests/test_dark_mode.py\ - 6 test cases

## Usage
Click the moon/sun icon in the navbar to toggle themes. The preference is saved automatically.

## JavaScript API
\\\javascript
darkMode.toggle()     // Toggle theme
darkMode.set('dark')  // Set specific theme
darkMode.get()        // Get current theme
darkMode.isDark()     // Check if dark mode
\\\

## Checklist
- [x] CSS variables for easy customization
- [x] All components styled
- [x] Smooth transitions
- [x] localStorage persistence
- [x] System preference detection
- [x] Chart.js color updates
- [x] Tests added